### PR TITLE
docs: add install method for aqua

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ $ brew install k1LoW/tap/roots
 $ go install github.com/k1LoW/roots@latest
 ```
 
+**[aqua](https://aquaproj.github.io/):**
+
+```console
+$ aqua g -i k1LoW/roots
+```
+
 **manually:**
 
 Download binary from [releases page](https://github.com/k1LoW/roots/releases)
-


### PR DESCRIPTION
This tools has been added to aqua's standard registry on [this PR](https://github.com/aquaproj/aqua-registry/pull/31825).
