### PR TITLE
feat(explorer): add concurrent directory exploration with worker pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ default: test
 ci: depsdev test
 
 test:
-	go test ./... -coverprofile=coverage.out -covermode=count
+	go test ./... -race -coverprofile=coverage.out -covermode=atomic
 
 lint:
 	golangci-lint run ./...

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -23,19 +23,19 @@ type Explorer struct {
 	ignoreDirs []string
 }
 
-// Config holds configuration for concurrent processing
+// Config holds configuration for concurrent processing.
 type Config struct {
 	MaxWorkers int // worker pool size (default: runtime.NumCPU() * 2)
 	BufferSize int // channel buffer size (default: 100)
 }
 
-// explorationJob represents a single directory exploration task
+// explorationJob represents a single directory exploration task.
 type explorationJob struct {
 	root  string
 	depth int
 }
 
-// explorationResult represents the result of a directory exploration
+// explorationResult represents the result of a directory exploration.
 type explorationResult struct {
 	roots []string
 	err   error
@@ -57,7 +57,7 @@ func New(fsys fs.FS, depth int, parent int, rootFiles, parentDirs [][]string, ig
 	}
 }
 
-// defaultConfig returns default concurrency configuration
+// defaultConfig returns default concurrency configuration.
 func defaultConfig() Config {
 	return Config{
 		MaxWorkers: runtime.NumCPU() * 2,
@@ -78,10 +78,7 @@ func (e *Explorer) ExploreRoots(ctx context.Context, baseDir string) ([]string, 
 	// Explore parent root directories
 	var root string
 	parent := e.parent
-	for {
-		if current == filepath.Dir(current) {
-			break
-		}
+	for current != filepath.Dir(current) {
 		func() {
 			for _, rf := range e.rootFiles {
 				fp := filepath.Join(append([]string{current}, rf...)...)
@@ -123,7 +120,7 @@ func (e *Explorer) ExploreRoots(ctx context.Context, baseDir string) ([]string, 
 	return roots, nil
 }
 
-// exploreRootsFromRootConcurrent explores root directories concurrently using worker pool
+// exploreRootsFromRootConcurrent explores root directories concurrently using worker pool.
 func (e *Explorer) exploreRootsFromRootConcurrent(ctx context.Context, root string, depth int, config Config) ([]string, error) {
 	if depth == 0 || root == "" {
 		return nil, nil
@@ -222,7 +219,7 @@ func (e *Explorer) exploreRootsFromRootConcurrent(ctx context.Context, root stri
 	return allRoots, nil
 }
 
-// worker processes exploration jobs
+// worker processes exploration jobs.
 func (e *Explorer) worker(ctx context.Context, jobs <-chan explorationJob, results chan<- explorationResult, config Config) {
 	for job := range jobs {
 		select {

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -6,8 +6,11 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
+	"sort"
 	"strings"
+	"sync"
 )
 
 type Explorer struct {
@@ -18,6 +21,24 @@ type Explorer struct {
 	rootFiles  [][]string
 	parentDirs [][]string
 	ignoreDirs []string
+}
+
+// Config holds configuration for concurrent processing
+type Config struct {
+	MaxWorkers int // worker pool size (default: runtime.NumCPU() * 2)
+	BufferSize int // channel buffer size (default: 100)
+}
+
+// explorationJob represents a single directory exploration task
+type explorationJob struct {
+	root  string
+	depth int
+}
+
+// explorationResult represents the result of a directory exploration
+type explorationResult struct {
+	roots []string
+	err   error
 }
 
 func New(fsys fs.FS, depth int, parent int, rootFiles, parentDirs [][]string, ignoreDirs []string) *Explorer {
@@ -33,6 +54,14 @@ func New(fsys fs.FS, depth int, parent int, rootFiles, parentDirs [][]string, ig
 		rootFiles:  rootFiles,
 		parentDirs: parentDirs,
 		ignoreDirs: ignoreDirs,
+	}
+}
+
+// defaultConfig returns default concurrency configuration
+func defaultConfig() Config {
+	return Config{
+		MaxWorkers: runtime.NumCPU() * 2,
+		BufferSize: 100,
 	}
 }
 
@@ -82,7 +111,8 @@ func (e *Explorer) ExploreRoots(ctx context.Context, baseDir string) ([]string, 
 	// Explore child root directories
 	depth := e.depth
 	root = strings.TrimLeft(root, e.sysRoot)
-	roots, err := e.exploreRootsFromRoot(ctx, root, depth)
+	config := defaultConfig()
+	roots, err := e.exploreRootsFromRootConcurrent(ctx, root, depth, config)
 	if err != nil {
 		return nil, err
 	}
@@ -93,33 +123,40 @@ func (e *Explorer) ExploreRoots(ctx context.Context, baseDir string) ([]string, 
 	return roots, nil
 }
 
-func (e *Explorer) exploreRootsFromRoot(ctx context.Context, root string, depth int) ([]string, error) {
-	var roots []string
+// exploreRootsFromRootConcurrent explores root directories concurrently using worker pool
+func (e *Explorer) exploreRootsFromRootConcurrent(ctx context.Context, root string, depth int, config Config) ([]string, error) {
 	if depth == 0 || root == "" {
 		return nil, nil
 	}
+
+	// Check current directory for root files
+	var currentRoots []string
 	func() {
 		for _, rf := range e.rootFiles {
 			fp := filepath.Join(append([]string{root}, rf...)...)
 			if _, err := fs.Stat(e.fsys, fp); err == nil {
-				roots = append(roots, root)
+				currentRoots = append(currentRoots, root)
 				return
 			}
 			for _, pd := range e.parentDirs {
 				d := filepath.Join(pd...)
 				if strings.HasSuffix(filepath.Dir(root), d) {
 					if _, err := fs.Stat(e.fsys, filepath.Dir(root)); err == nil {
-						roots = append(roots, root)
+						currentRoots = append(currentRoots, root)
 						return
 					}
 				}
 			}
 		}
 	}()
+
 	entries, err := fs.ReadDir(e.fsys, root)
 	if err != nil {
-		return nil, err
+		return currentRoots, nil // Return current roots even if we can't read subdirectories
 	}
+
+	// Filter and collect subdirectories
+	var subdirs []string
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -127,13 +164,73 @@ func (e *Explorer) exploreRootsFromRoot(ctx context.Context, root string, depth 
 		if slices.Contains(e.ignoreDirs, entry.Name()) {
 			continue
 		}
-		subRoot := filepath.Join(root, entry.Name())
-		subRoots, err := e.exploreRootsFromRoot(ctx, subRoot, depth-1)
-		if err != nil {
-			return nil, err
-		}
-		roots = append(roots, subRoots...)
+		subdirs = append(subdirs, filepath.Join(root, entry.Name()))
 	}
 
-	return roots, nil
+	if len(subdirs) == 0 {
+		return currentRoots, nil
+	}
+	// Set up worker pool
+	workerCount := config.MaxWorkers
+	if workerCount <= 0 {
+		workerCount = runtime.NumCPU() * 2
+	}
+
+	jobs := make(chan explorationJob, config.BufferSize)
+	results := make(chan explorationResult, config.BufferSize)
+
+	// Start workers
+	var wg sync.WaitGroup
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			e.worker(ctx, jobs, results, config)
+		}()
+	}
+
+	// Send jobs
+	go func() {
+		defer close(jobs)
+		for _, subdir := range subdirs {
+			select {
+			case jobs <- explorationJob{root: subdir, depth: depth - 1}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Collect results
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var allRoots []string
+	allRoots = append(allRoots, currentRoots...)
+
+	for result := range results {
+		if result.err != nil {
+			return nil, result.err
+		}
+		allRoots = append(allRoots, result.roots...)
+	}
+
+	// Sort results to ensure deterministic output
+	sort.Strings(allRoots)
+	return allRoots, nil
+}
+
+// worker processes exploration jobs
+func (e *Explorer) worker(ctx context.Context, jobs <-chan explorationJob, results chan<- explorationResult, config Config) {
+	for job := range jobs {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			roots, err := e.exploreRootsFromRootConcurrent(ctx, job.root, job.depth, config)
+			results <- explorationResult{roots: roots, err: err}
+		}
+	}
 }


### PR DESCRIPTION
This pull request introduces concurrency improvements to the directory exploration logic in the `Explorer` class, adds new configuration options for worker pool management, and updates the testing mode in the `Makefile`. The most significant changes include implementing a concurrent exploration method, adding a worker pool, and refining the test configuration.

### Concurrency improvements in `Explorer`:

* **Added concurrent exploration method**: Replaced the single-threaded `exploreRootsFromRoot` method with a new `exploreRootsFromRootConcurrent` function that uses a worker pool to process directory exploration tasks concurrently. This includes handling jobs and results through buffered channels and ensuring deterministic output by sorting results. (`explorer/explorer.go`, [explorer/explorer.goL96-R235](diffhunk://#diff-b973ebcbcd81d6f5eb333f7b87b7366e9886270ccdef647b80df03f94a1156dcL96-R235))
* **Introduced worker pool**: Added a `worker` method to process exploration jobs using a configurable number of workers. This improves scalability and performance for large directory structures. (`explorer/explorer.go`, [explorer/explorer.goL96-R235](diffhunk://#diff-b973ebcbcd81d6f5eb333f7b87b7366e9886270ccdef647b80df03f94a1156dcL96-R235))

### Configuration additions:

* **Added `Config` struct**: Introduced a `Config` struct to define concurrency settings such as `MaxWorkers` (worker pool size) and `BufferSize` (channel buffer size). A `defaultConfig` function was added to provide sensible defaults based on the number of CPU cores. (`explorer/explorer.go`, [[1]](diffhunk://#diff-b973ebcbcd81d6f5eb333f7b87b7366e9886270ccdef647b80df03f94a1156dcR26-R43) [[2]](diffhunk://#diff-b973ebcbcd81d6f5eb333f7b87b7366e9886270ccdef647b80df03f94a1156dcR60-R67)

### Testing updates:

* **Updated test mode in `Makefile`**: Changed the `go test` command to include the `-race` flag for detecting race conditions and switched the coverage mode to `atomic` for improved accuracy in concurrent environments. (`Makefile`, [MakefileL8-R8](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L8-R8))